### PR TITLE
Feature: subpixel interpolation

### DIFF
--- a/examples/tiltxcorr_example_simulated_data.py
+++ b/examples/tiltxcorr_example_simulated_data.py
@@ -83,7 +83,8 @@ if __name__ == "__main__":
     # setup tilt series geometry
     tilt_axis_angle = 85
     tilt_angles = np.linspace(-60, 60, num=61, endpoint=True)
-    shifts = np.random.uniform(low=-5, high=5, size=(len(tilt_angles), 2))
+    rng = np.random.default_rng(1414)
+    shifts = rng.uniform(low=-5, high=5, size=(len(tilt_angles), 2))
     shifts[tilt_angles == 0] = 0
 
     # simulate tilt series

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -40,6 +40,7 @@ dependencies = [
     "einops",
     "torch-affine-utils",
     "torch-transform-image",
+    "torch-fourier-filter",
 ]
 
 # https://peps.python.org/pep-0621/#dependencies-optional-dependencies

--- a/src/torch_tiltxcorr/utils.py
+++ b/src/torch_tiltxcorr/utils.py
@@ -3,7 +3,7 @@ import torch
 from torch_affine_utils.transforms_2d import R, S, T
 from torch_affine_utils import homogenise_coordinates
 from torch_transform_image import affine_transform_image_2d
-from torch_fourier_filter.bandpass import bandpass_filter
+
 
 def apply_stretch_perpendicular_to_tilt_axis(
     image: torch.Tensor,
@@ -35,8 +35,8 @@ def calculate_cross_correlation(img1, img2):
     img1_fft = torch.fft.rfft2(img1)
     img2_fft = torch.fft.rfft2(img2)
     cross_power = img1_fft * torch.conj(img2_fft)
-    normalized_cross_power = cross_power / (torch.abs(cross_power) + 1e-8)
-    result = torch.fft.irfft2(normalized_cross_power, s=img1.shape)
+    cross_power = cross_power / (torch.abs(cross_power) + 1e-8)
+    result = torch.fft.irfft2(cross_power, s=img1.shape)
     result = torch.real(torch.fft.ifftshift(result, dim=(-2, -1)))
     return result
 


### PR DESCRIPTION
Update the shift detection from the correlation image by doing parabolic interpolation of the peak. 

Note that I changed slightly changed calculation of the correlation image to use an ifftshift at the end. This is because the peak is often around the 0 frequency which make subpixel interpolation difficult (close to edge) -> now we can just skip interpolating the pixel if it is at an image edge.

*edit: just wanted to add that I already wrote this functionality in tttsa and thought it made sense to include it here