### PR TITLE
make lowpass cutoff a keyword with sensible default

### DIFF
--- a/src/torch_tiltxcorr/tiltxcorr.py
+++ b/src/torch_tiltxcorr/tiltxcorr.py
@@ -19,7 +19,7 @@ def tiltxcorr(
     tilt_series: torch.Tensor,  # (b, h, w)
     tilt_angles: torch.Tensor,  # (b, )
     tilt_axis_angle: float,
-    low_pass_cutoff: float,  # cycles/px
+    low_pass_cutoff: float = 0.25,  # cycles/px
 ) -> torch.Tensor:  # (b, 2) yx shifts
     # extract shape
     b, h, w = tilt_series.shape

--- a/src/torch_tiltxcorr/tiltxcorr_no_stretch.py
+++ b/src/torch_tiltxcorr/tiltxcorr_no_stretch.py
@@ -8,7 +8,7 @@ from torch_tiltxcorr.utils import taper_image_edges, calculate_cross_correlation
 def tiltxcorr_no_stretch(
     tilt_series: torch.Tensor,
     tilt_angles: torch.Tensor,  # (b, )
-    low_pass_cutoff: float,  # cycles/px
+    low_pass_cutoff: float = 0.25,  # cycles/px
 ) -> torch.Tensor:
     """Find coarse shifts of images without stretching along tilt axis."""
     # extract shape

--- a/src/torch_tiltxcorr/tiltxcorr_with_pretilt_offset.py
+++ b/src/torch_tiltxcorr/tiltxcorr_with_pretilt_offset.py
@@ -19,7 +19,7 @@ def tiltxcorr_with_pretilt_offset(
     tilt_series: torch.Tensor,  # (b, h, w)
     tilt_angles: torch.Tensor,  # (b, )
     tilt_axis_angle: float,
-    low_pass_cutoff: float,  # cycles/px
+    low_pass_cutoff: float = 0.25,  # cycles/px
     pretilt_range: tuple[float, float] = (-30.0, 30.0),  # search range in degrees
     max_iter: int = 10,  # max iterations for Brent's method
 ) -> tuple[torch.Tensor, float]:  # (b, 2) yx shifts and optimal pretilt offset


### PR DESCRIPTION
This might be an overlooked parameter, and running with 0.5 makes performance a lot poorer compared to 0.25 (the IMOD default)