### PR TITLE
rename pretilt_offset to sample_tilt and add integration tests

### DIFF
--- a/README.md
+++ b/README.md
@@ -74,30 +74,32 @@ torch-tiltxcorr performs coarse tilt series alignment by:
    - Transforming the shift to account for the stretch applied to the image
 4. Accumulating shifts to align the entire series
 
-### With Pretilt Offset Search
+### With Sample Tilt Estimation
 
-For samples with significant pretilt, use `tiltxcorr_with_pretilt_offset` to automatically find the optimal pretilt offset:
+If a sample is physically tilted +5° around the tilt axis in the microscope, then at nominal 0° stage tilt the beam sees the sample at +5°.
+
+By accounting for this during tiltxcorr, we can estimate sample rotation around the tilt axis is in the microscope.
 
 ```python
 import torch
 from torch_fourier_shift import fourier_shift_image_2d
-from torch_tiltxcorr import tiltxcorr_with_pretilt_offset
+from torch_tiltxcorr import tiltxcorr_with_sample_tilt_estimation
 
 # Load or create your tilt series
 tilt_series = torch.randn(61, 512, 512)
 tilt_angles = torch.linspace(-60, 60, steps=61)
 tilt_axis_angle = 45
 
-# Run tiltxcorr with pretilt offset search
-shifts, optimal_pretilt = tiltxcorr_with_pretilt_offset(
-    tilt_series=tilt_series,
-    tilt_angles=tilt_angles,
-    tilt_axis_angle=tilt_axis_angle,
-    low_pass_cutoff=0.5, # cycles/px
-    pretilt_range=(-30.0, 30.0),  # search range in degrees
+# Run tiltxcorr with sample tilt estimation
+shifts, sample_tilt = tiltxcorr_with_sample_tilt_estimation(
+   tilt_series=tilt_series,
+   tilt_angles=tilt_angles,
+   tilt_axis_angle=tilt_axis_angle,
+   low_pass_cutoff=0.5,  # cycles/px
+   sample_tilt_range=(-30.0, 30.0),  # search range in degrees
 )
 # shifts shape: (batch, 2) tensor of (dy, dx) shifts which center each tilt image
-# optimal_pretilt: float value optimal pretilt offset in degrees
+# sample_tilt: float value for component of sample tilt about the stage in degrees
 
 # Apply shifts to align the tilt series
 aligned_tilt_series = fourier_shift_image_2d(tilt_series, shifts=shifts)

--- a/examples/tiltxcorr_with_sample_tilt_estimation.py
+++ b/examples/tiltxcorr_with_sample_tilt_estimation.py
@@ -1,0 +1,194 @@
+# /// script
+# requires-python = ">=3.10"
+# dependencies = [
+#   "einops",
+#   "numpy",
+#   "torch",
+#   "torch-affine-utils",
+#   "torch-image-interpolation",
+#   "torch-fourier-slice",
+#   "torch-fourier-shift",
+#   "torch-fourier-filter",
+#   "scipy",
+#   "torch-tiltxcorr",
+# ]
+# exclude-newer = "2025-12-20T00:00:00Z"
+# [tool.uv.sources]
+# torch-tiltxcorr = { path = "../" }
+# ///
+"""
+Example: tiltxcorr_with_sample_tilt_estimation with simulated data
+
+This example demonstrates how to use tiltxcorr_with_sample_tilt_estimation to estimate
+the component of the sample tilt angle around the tilt axis.
+
+The sample tilt represents the physical angle at which the sample sits
+in the microscope. The effective stage tilt angle seen by the beam is:
+true_tilt_angle = nominal_stage_angle + sample_tilt
+"""
+import einops
+import numpy as np
+import torch
+import torch.nn.functional as F
+from torch_affine_utils.transforms_3d import Rx, Ry, Rz
+from torch_affine_utils.utils import homogenise_coordinates
+from torch_image_interpolation import insert_into_image_3d
+from torch_fourier_slice import project_3d_to_2d
+from torch_fourier_shift import fourier_shift_image_2d
+import napari
+
+from torch_tiltxcorr import tiltxcorr_with_sample_tilt_estimation
+
+
+def generate_tilted_plane_tilt_series(
+    sample_tilt_x: float = 0.0,
+    sample_tilt_y: float = 0.0,
+    d: int = 128,
+    n_points_on_plane: int = 100,
+    tilt_angles_deg: torch.Tensor | None = None,
+    tilt_axis_angle: float = 85.0,
+    seed: int = 42,
+) -> tuple[torch.Tensor, torch.Tensor]:
+    """
+    Generate a synthetic tilt series from points on a tilted plane.
+
+    Parameters
+    ----------
+    sample_tilt_x : float
+        Sample tilt around x-axis in degrees
+    sample_tilt_y : float
+        Sample tilt around y-axis in degrees
+    d : int
+        Volume dimension (cubic volume d x d x d)
+    n_points_on_plane : int
+        Number of random points to place on the plane
+    tilt_angles_deg : torch.Tensor, optional
+        Tilt angles in degrees. If None, uses linspace(-60, 60, 41)
+    tilt_axis_angle : float
+        Tilt axis angle in degrees
+    seed : int
+        Random seed for reproducibility
+
+    Returns
+    -------
+    tilt_series : torch.Tensor
+        Generated tilt series (n_tilts, h, w)
+    tilt_angles : torch.Tensor
+        Tilt angles in degrees (n_tilts,)
+    """
+    # Setup dimensions
+    d2 = d // 2
+    volume_center_zyx = torch.tensor([d2, d2, d2]).float()
+
+    # Setup plane geometry - sample tilt in microscope
+    M_tilt_sample_in_scope = Ry(sample_tilt_y, zyx=True) @ Rx(sample_tilt_x, zyx=True)
+
+    # Generate points on a tilted xy plane in the microscope
+    # Create regular grid across xy
+    y = torch.linspace(-d2, d2, steps=d)
+    x = torch.linspace(-d2, d2, steps=d)
+    yy, xx = torch.meshgrid(y, x, indexing="ij")
+    yx = einops.rearrange([yy, xx], "yx h w -> h w yx")
+    zyx = F.pad(yx, (1, 0), value=0)
+    xy_plane_zyxw = homogenise_coordinates(zyx)
+    xy_plane_zyxw_col = einops.rearrange(xy_plane_zyxw, "h w zyxw -> (h w) zyxw 1")
+
+    # Randomly sample points from grid
+    b = len(xy_plane_zyxw_col)
+    rng = np.random.default_rng(seed=seed)
+    idx_subset = rng.choice(b, size=(n_points_on_plane,), replace=False)
+
+    # Apply sample tilt transformation to points
+    points_in_scope_zyxw_col = xy_plane_zyxw_col[idx_subset]
+    points_in_scope_zyxw_col = M_tilt_sample_in_scope @ points_in_scope_zyxw_col
+    points_in_scope_zyxw = einops.rearrange(points_in_scope_zyxw_col, "b zyxw 1 -> b zyxw")
+    points_in_scope_zyx = points_in_scope_zyxw[..., :3]
+
+    # Create 3D volume with points on the tilted plane
+    points_in_volume = points_in_scope_zyx + volume_center_zyx
+    volume_in_scope = torch.zeros((d, d, d)).float()
+    volume_in_scope, _ = insert_into_image_3d(
+        values=torch.ones((n_points_on_plane,)),
+        coordinates=points_in_volume,
+        image=volume_in_scope
+    )
+
+    # Setup tilt angles
+    if tilt_angles_deg is None:
+        tilt_angles_deg = torch.linspace(-60, 60, steps=41)
+
+    # Setup scope2detector transformation
+    M_scope2detector = Rz(tilt_axis_angle, zyx=True) @ Ry(tilt_angles_deg, zyx=True)
+
+    # Generate tilt series
+    M_scope2detector_rot = M_scope2detector[:, :3, :3]
+    M_scope2detector_rot_inv = torch.linalg.pinv(M_scope2detector_rot)
+    tilt_series = project_3d_to_2d(
+        volume=volume_in_scope,
+        rotation_matrices=M_scope2detector_rot_inv,
+        zyx_matrices=True,
+    )
+
+    return tilt_series, tilt_angles_deg
+
+
+if __name__ == "__main__":
+    print("=" * 70)
+    print("Simulated Tilt Series with Sample Tilt")
+    print("=" * 70)
+    print()
+
+    # Setup parameters
+    true_sample_tilt_y = 15.0  # Ground truth: sample is tilted +15 degrees around Y-axis
+    d = 128
+    tilt_axis_angle = 85.0
+    tilt_angles_deg = torch.linspace(-60, 60, steps=41)
+    low_pass_cutoff = 0.5
+
+    print(f"Simulation parameters:")
+    print(f"  True sample tilt (Y-axis): {true_sample_tilt_y}°")
+    print(f"  Volume size: {d}³")
+    print(f"  Tilt axis angle: {tilt_axis_angle}°")
+    print(f"  Tilt angles: {len(tilt_angles_deg)} images from {tilt_angles_deg.min()}° to {tilt_angles_deg.max()}°")
+    print(f"  Low-pass cutoff: {low_pass_cutoff} cycles/px")
+    print()
+
+    # Simulate tilt series with known sample tilt
+    print("Simulating tilt series with tilted plane...")
+    tilt_series, tilt_angles = generate_tilted_plane_tilt_series(
+        sample_tilt_x=0.0,
+        sample_tilt_y=true_sample_tilt_y,
+        d=d,
+        n_points_on_plane=100,
+        tilt_angles_deg=tilt_angles_deg,
+        tilt_axis_angle=tilt_axis_angle,
+        seed=42,
+    )
+    print(f"  Tilt series shape: {tilt_series.shape}")
+    print()
+
+    # Run tiltxcorr_with_sample_tilt to recover the sample tilt
+    print("Running tiltxcorr_with_sample_tilt...")
+    print("  Searching for optimal sample tilt angle...")
+    shifts, estimated_sample_tilt = tiltxcorr_with_sample_tilt_estimation(
+        tilt_series=tilt_series,
+        tilt_angles=tilt_angles,
+        tilt_axis_angle=tilt_axis_angle,
+        low_pass_cutoff=low_pass_cutoff,
+        sample_tilt_range=(-30.0, 30.0),
+        max_iter=15,
+    )
+    print()
+
+    # Display results
+    print("=" * 70)
+    print("Results")
+    print("=" * 70)
+    print(f"  Ground truth sample tilt (Y-axis):      {true_sample_tilt_y:6.2f}°")
+    print(f"  Estimated sample tilt:                  {estimated_sample_tilt:6.2f}°")
+    print(f"  Error:                                  {abs(estimated_sample_tilt - true_sample_tilt_y):6.2f}°")
+    print()
+    print(f"  Ground truth shifts:                     all 0")
+    print(f"  Mean estimated shift magnitude:        {torch.norm(shifts, dim=1).mean():6.2f} pixels")
+    print(f"  Max estimated shift magnitude:         {torch.norm(shifts, dim=1).max():6.2f} pixels")
+    print()

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -42,14 +42,18 @@ dependencies = [
     "torch-affine-utils",
     "torch-transform-image",
     "torch-fourier-filter",
-    "torch-fourier-rescale",
 ]
 
 # https://peps.python.org/pep-0621/#dependencies-optional-dependencies
 # "extras" (e.g. for `pip install .[test]`)
 [project.optional-dependencies]
 # add dependencies used for testing here
-test = ["pytest", "pytest-cov"]
+test = [
+    "pytest",
+    "pytest-cov",
+    "torch-fourier-slice",
+]
+
 # add anything else you like to have in your dev environment here
 dev = [
     "ipython",

--- a/src/torch_tiltxcorr/__init__.py
+++ b/src/torch_tiltxcorr/__init__.py
@@ -11,10 +11,10 @@ __email__ = "alisterburt@gmail.com"
 
 from torch_tiltxcorr.tiltxcorr import tiltxcorr
 from torch_tiltxcorr.tiltxcorr_no_stretch import tiltxcorr_no_stretch
-from torch_tiltxcorr.tiltxcorr_with_pretilt_offset import tiltxcorr_with_pretilt_offset
+from torch_tiltxcorr.tiltxcorr_with_sample_tilt_estimation import tiltxcorr_with_sample_tilt_estimation
 
 __all__ = [
     'tiltxcorr',
     'tiltxcorr_no_stretch',
-    'tiltxcorr_with_pretilt_offset'
+    'tiltxcorr_with_sample_tilt_estimation'
 ]

--- a/tests/test_tiltxcorr_with_sample_tilt_estimation.py
+++ b/tests/test_tiltxcorr_with_sample_tilt_estimation.py
@@ -1,0 +1,165 @@
+"""Integration tests for tiltxcorr_with_sample_tilt using simulated data."""
+import torch
+import torch.nn.functional as F
+import pytest
+import numpy as np
+import einops
+
+from torch_affine_utils.transforms_3d import Rx, Ry, Rz
+from torch_affine_utils.utils import homogenise_coordinates
+from torch_image_interpolation import insert_into_image_3d
+from torch_fourier_slice import project_3d_to_2d
+
+from torch_tiltxcorr import tiltxcorr_with_sample_tilt_estimation
+
+
+def _generate_tilted_plane_tilt_series(
+    sample_tilt_x: float = 0.0,
+    sample_tilt_y: float = 0.0,
+    d: int = 128,
+    n_points_on_plane: int = 100,
+    tilt_angles_deg: torch.Tensor | None = None,
+    tilt_axis_angle: float = 85.0,
+    seed: int = 42,
+) -> tuple[torch.Tensor, torch.Tensor, float]:
+    """
+    Generate a synthetic tilt series from points on a tilted plane.
+
+    Parameters
+    ----------
+    sample_tilt_x : float
+        Sample tilt around x-axis in degrees
+    sample_tilt_y : float
+        Sample tilt around y-axis in degrees
+    d : int
+        Volume dimension (cubic volume d x d x d)
+    n_points_on_plane : int
+        Number of random points to place on the plane
+    tilt_angles_deg : torch.Tensor, optional
+        Tilt angles in degrees. If None, uses linspace(-60, 60, 41)
+    tilt_axis_angle : float
+        Tilt axis angle in degrees
+    seed : int
+        Random seed for reproducibility
+
+    Returns
+    -------
+    tilt_series : torch.Tensor
+        Generated tilt series (n_tilts, h, w)
+    tilt_angles : torch.Tensor
+        Tilt angles in degrees (n_tilts,)
+    tilt_axis_angle : float
+        Tilt axis angle in degrees
+    """
+    # Setup dimensions
+    d2 = d // 2
+    volume_center_zyx = torch.tensor([d2, d2, d2]).float()
+
+    # Setup plane geometry - sample tilt in microscope
+    M_tilt_sample_in_scope = Ry(sample_tilt_y, zyx=True) @ Rx(sample_tilt_x, zyx=True)
+
+    # Generate points on a tilted xy plane in the microscope
+    # Create regular grid across xy
+    y = torch.linspace(-d2, d2, steps=d)
+    x = torch.linspace(-d2, d2, steps=d)
+    yy, xx = torch.meshgrid(y, x, indexing="ij")
+    yx = einops.rearrange([yy, xx], "yx h w -> h w yx")
+    zyx = F.pad(yx, (1, 0), value=0)
+    xy_plane_zyxw = homogenise_coordinates(zyx)
+    xy_plane_zyxw_col = einops.rearrange(xy_plane_zyxw, "h w zyxw -> (h w) zyxw 1")
+
+    # Randomly sample points from grid
+    b = len(xy_plane_zyxw_col)
+    rng = np.random.default_rng(seed=seed)
+    idx_subset = rng.choice(b, size=(n_points_on_plane,), replace=False)
+
+    # Apply sample tilt transformation to points
+    points_in_scope_zyxw_col = xy_plane_zyxw_col[idx_subset]
+    points_in_scope_zyxw_col = M_tilt_sample_in_scope @ points_in_scope_zyxw_col
+    points_in_scope_zyxw = einops.rearrange(points_in_scope_zyxw_col, "b zyxw 1 -> b zyxw")
+    points_in_scope_zyx = points_in_scope_zyxw[..., :3]
+
+    # Create 3D volume with points on the tilted plane
+    points_in_volume = points_in_scope_zyx + volume_center_zyx
+    volume_in_scope = torch.zeros((d, d, d)).float()
+    volume_in_scope, _ = insert_into_image_3d(
+        values=torch.ones((n_points_on_plane,)),
+        coordinates=points_in_volume,
+        image=volume_in_scope
+    )
+
+    # Setup tilt angles
+    if tilt_angles_deg is None:
+        tilt_angles_deg = torch.linspace(-60, 60, steps=41)
+
+    # Setup scope2detector transformation
+    M_scope2detector = Rz(tilt_axis_angle, zyx=True) @ Ry(tilt_angles_deg, zyx=True)
+
+    # Generate tilt series
+    M_scope2detector_rot = M_scope2detector[:, :3, :3]
+    M_scope2detector_rot_inv = torch.linalg.pinv(M_scope2detector_rot)
+    tilt_series = project_3d_to_2d(
+        volume=volume_in_scope,
+        rotation_matrices=M_scope2detector_rot_inv,
+        zyx_matrices=True,
+    )
+
+    return tilt_series, tilt_angles_deg, tilt_axis_angle
+
+
+@pytest.mark.parametrize(
+    "sample_tilt_x, sample_tilt_y, max_error",
+    [
+        # Y-axis only (stage tilt direction - should be estimated well)
+        (0.0, 0.0, 0.05),      # zero tilt baseline
+        (0.0, 15.0, 0.05),     # positive Y tilt
+        (0.0, -12.0, 0.05),    # negative Y tilt
+        (0.0, 25.0, 0.1),      # larger positive Y tilt
+
+        # Combined X and Y tilts (more realistic scenario, expect inaccuracies)
+        (3.0, 10.0, 0.5),  # small X, moderate Y
+        (-4.0, 10.0, 0.5), # negative X, positive Y
+        (5.0, -10.0, 0.5), # positive X, negative Y
+    ],
+)
+def test_tiltxcorr_with_sample_tilt_estimation(
+    sample_tilt_x: float,
+    sample_tilt_y: float,
+    max_error: float,
+):
+    """
+    Test recovery of sample tilt with various combinations of X and Y tilts.
+
+    The tiltxcorr_with_sample_tilt function optimizes a single angle parameter,
+    which primarily captures the sample tilt around the microscope stage tilt axis).
+    X-axis tilts are additional sample tilt perpendicular to the tilt axis.
+    """
+    # Generate tilt series with specified sample tilts
+    tilt_series, tilt_angles, tilt_axis_angle = _generate_tilted_plane_tilt_series(
+        sample_tilt_x=sample_tilt_x,
+        sample_tilt_y=sample_tilt_y,
+        d=128,
+        n_points_on_plane=100,
+        tilt_axis_angle=85.0,
+        seed=42,
+    )
+
+    # Run tiltxcorr_with_sample_tilt
+    shifts, optimal_sample_tilt = tiltxcorr_with_sample_tilt_estimation(
+        tilt_series=tilt_series,
+        tilt_angles=tilt_angles,
+        tilt_axis_angle=tilt_axis_angle,
+        low_pass_cutoff=0.5,
+        sample_tilt_range=(-30.0, 30.0),
+        max_iter=15,
+    )
+
+    # Verify estimated sample tilt is close to expected value
+    error = abs(optimal_sample_tilt - sample_tilt_y)
+    assert error < max_error, (
+        f"Sample tilt recovery failed:\n"
+        f"  Input: sample_tilt_x={sample_tilt_x}°, sample_tilt_y={sample_tilt_y}°\n"
+        f"  Expected: {sample_tilt_y}°\n"
+        f"  Got: {optimal_sample_tilt:.3f}°\n"
+        f"  Error: {error:.3f}° (max allowed: {max_error}°)"
+    )

--- a/tests/test_torch_tiltxcorr.py
+++ b/tests/test_torch_tiltxcorr.py
@@ -6,10 +6,10 @@ from torch_tiltxcorr.utils import (
 
 
 def test_shift_detection():
-    a = torch.zeros((24, 24))
-    a[13, 13] = 1
-    b = torch.zeros((24, 24))
-    b[12, 12] = 1
+    a = torch.zeros((10, 10))
+    a[6, 6] = 1
+    b = torch.zeros((10, 10))
+    b[5, 5] = 1
 
     ccc = calculate_cross_correlation(a, a)
     shift = get_shift_from_correlation_image(ccc)
@@ -20,9 +20,9 @@ def test_shift_detection():
     assert dy == pytest.approx(1., 1e-3)
     assert dx == pytest.approx(1., 1e-3)
 
-    b = torch.zeros((24, 24))
-    b[12, 12] = 2.5
-    b[11, 12] = 2.5
+    b = torch.zeros((10, 10))
+    b[5, 5] = 2.5
+    b[4, 5] = 2.5
 
     ccc = calculate_cross_correlation(a, b)
     dy, dx = get_shift_from_correlation_image(ccc)


### PR DESCRIPTION
this makes it much clearer what is physically modelled by the pretilt offset

confirmed with nice tests and an example with simulated data

```txt
======================================================================
Simulated Tilt Series with Sample Tilt
======================================================================

Simulation parameters:
  True sample tilt (Y-axis): 15.0°
  Volume size: 128³
  Tilt axis angle: 85.0°
  Tilt angles: 41 images from -60.0° to 60.0°
  Low-pass cutoff: 0.5 cycles/px

Simulating tilt series with tilted plane...
  Tilt series shape: torch.Size([41, 128, 128])

Running tiltxcorr_with_sample_tilt...
  Searching for optimal sample tilt angle...

======================================================================
Results
======================================================================
  Ground truth sample tilt (Y-axis):       15.00°
  Estimated sample tilt:                   15.02°
  Error:                                    0.02°

  Ground truth shifts:                     all 0
  Mean estimated shift magnitude:          0.01 pixels
  Max estimated shift magnitude:           0.03 pixels
```

